### PR TITLE
[Feat] - Auth API 연동

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,7 +10,9 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   async rewrites() {
     const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
-    if (!apiBase) {return [];}
+    if (!apiBase) {
+      return [];
+    }
     return [
       {
         source: '/api/:path*',

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,10 +9,12 @@ const nextConfig: NextConfig = {
   transpilePackages: ['@muneo/design-system'],
   reactCompiler: true,
   async rewrites() {
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!apiBase) {return [];}
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/:path*`,
+        destination: `${apiBase}/api/:path*`,
       },
     ];
   },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,14 @@ const withVanillaExtract = createVanillaExtractPlugin({
 const nextConfig: NextConfig = {
   transpilePackages: ['@muneo/design-system'],
   reactCompiler: true,
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/:path*`,
+      },
+    ];
+  },
   experimental: {
     viewTransition: true,
     staleTimes: {

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,4 +1,10 @@
-import { type AuthApiError, type AuthUser, type LoginRequest, type SignupRequest } from '@/types/auth';
+import {
+  type AuthApiError,
+  type AuthUser,
+  type LoginRequest,
+  type SignupRequest,
+  type SocialSignupRequest,
+} from '@/types/auth';
 import { client } from './client';
 
 interface ApiSuccessResponse<T> {
@@ -54,6 +60,25 @@ export const logout = async (): Promise<void> => {
 export const refresh = async (): Promise<AuthUser> => {
   try {
     const res = await client.post('api/v1/auth/refresh').json<ApiSuccessResponse<AuthUser>>();
+    return res.result;
+  } catch (e) {
+    throw toAuthApiError(e);
+  }
+};
+
+interface KakaoLoginUrlResult {
+  provider: string;
+  loginUrl: string;
+}
+
+export const getKakaoLoginUrl = async (): Promise<KakaoLoginUrlResult> => {
+  const res = await client.get('api/v1/auth/oauth/kakao').json<ApiSuccessResponse<KakaoLoginUrlResult>>();
+  return res.result;
+};
+
+export const socialSignup = async (data: SocialSignupRequest): Promise<AuthUser> => {
+  try {
+    const res = await client.post('api/v1/auth/social/signup', { json: data }).json<ApiSuccessResponse<AuthUser>>();
     return res.result;
   } catch (e) {
     throw toAuthApiError(e);

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,61 @@
+import { type AuthApiError, type AuthUser, type LoginRequest, type SignupRequest } from '@/types/auth';
+import { client } from './client';
+
+interface ApiSuccessResponse<T> {
+  success: true;
+  result: T;
+}
+
+function isClientError(e: unknown): e is Error & { status: number; body: unknown } {
+  return e instanceof Error && 'status' in e && 'body' in e;
+}
+
+export function isAuthApiError(e: unknown): e is AuthApiError {
+  return isClientError(e) && typeof (e.body as Record<string, unknown>)?.code === 'string';
+}
+
+function toAuthApiError(e: unknown): AuthApiError {
+  if (isClientError(e) && e.body !== null && typeof e.body === 'object') {
+    const body = e.body as Record<string, unknown>;
+    return {
+      code: typeof body.code === 'string' ? body.code : 'UNKNOWN',
+      error: body.error as AuthApiError['error'],
+    };
+  }
+  return { code: 'UNKNOWN' };
+}
+
+export const signup = async (data: SignupRequest): Promise<AuthUser> => {
+  try {
+    const res = await client.post('api/v1/users/signup', { json: data }).json<ApiSuccessResponse<AuthUser>>();
+    return res.result;
+  } catch (e) {
+    throw toAuthApiError(e);
+  }
+};
+
+export const login = async (data: LoginRequest): Promise<AuthUser> => {
+  try {
+    const res = await client.post('api/v1/users/login', { json: data }).json<ApiSuccessResponse<AuthUser>>();
+    return res.result;
+  } catch (e) {
+    throw toAuthApiError(e);
+  }
+};
+
+export const logout = async (): Promise<void> => {
+  try {
+    await client.post('api/v1/users/logout');
+  } catch (e) {
+    throw toAuthApiError(e);
+  }
+};
+
+export const refresh = async (): Promise<AuthUser> => {
+  try {
+    const res = await client.post('api/v1/auth/refresh').json<ApiSuccessResponse<AuthUser>>();
+    return res.result;
+  } catch (e) {
+    throw toAuthApiError(e);
+  }
+};

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,17 +1,26 @@
 import ky from 'ky';
 
+const apiBaseUrl = typeof window === 'undefined' ? process.env.NEXT_PUBLIC_API_BASE_URL : window.location.origin;
+
 export const client = ky.create({
-  prefixUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  prefixUrl: apiBaseUrl,
   timeout: 10000,
+  credentials: 'include',
   headers: {
     'Content-Type': 'application/json',
   },
   hooks: {
     afterResponse: [
       async (_request, _options, response) => {
-        // NOTE: 공통 에러 처리 (401 리다이렉트 등)
+        // 공통 에러 처리 (401 리다이렉트 등) — 응답 body를 에러에 첨부해 호출자가 에러 코드 파싱 가능
         if (!response.ok) {
-          throw new Error(`API Error: ${response.status}`);
+          const body = await response
+            .clone()
+            .json()
+            .catch(() => null);
+          const error = new Error(`API Error: ${response.status}`);
+          Object.assign(error, { status: response.status, body });
+          throw error;
         }
       },
     ],

--- a/apps/web/src/api/history.ts
+++ b/apps/web/src/api/history.ts
@@ -1,0 +1,48 @@
+import { client } from './client';
+
+interface EstimateInput {
+  공종: string[];
+  공간유형: string;
+  평수: number;
+  [key: string]: unknown;
+}
+
+interface RiskSummary {
+  total_risk_items: number;
+  chips: { 누락: number; 중복: number; 불분명: number };
+}
+
+interface RiskResult {
+  report: {
+    summary: RiskSummary;
+  };
+}
+
+interface RiskInput {
+  spaceType: string;
+  pyeong: number;
+  companyName: string;
+  [key: string]: unknown;
+}
+
+export interface EstimateItem {
+  id: string;
+  user_id: string;
+  created_at: string;
+  input: EstimateInput;
+  result: unknown;
+}
+
+export interface RiskItem {
+  id: string;
+  user_id: string;
+  created_at: string;
+  input: RiskInput;
+  result: RiskResult;
+}
+
+export const getEstimates = (userId: number): Promise<EstimateItem[]> =>
+  client.get('api/v1/estimates', { headers: { 'x-user-id': String(userId) } }).json<EstimateItem[]>();
+
+export const getRiskDetections = (userId: number): Promise<RiskItem[]> =>
+  client.get('api/v1/risk-detector', { headers: { 'x-user-id': String(userId) } }).json<RiskItem[]>();

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -1,3 +1,3 @@
 export { client } from './client';
-export { isAuthApiError, login, logout, refresh, signup } from './auth';
+export { getKakaoLoginUrl, isAuthApiError, login, logout, refresh, signup, socialSignup } from './auth';
 export { getEstimates, getRiskDetections } from './history';

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -1,1 +1,3 @@
 export { client } from './client';
+export { isAuthApiError, login, logout, refresh, signup } from './auth';
+export { getEstimates, getRiskDetections } from './history';

--- a/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
+++ b/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
@@ -48,6 +48,7 @@ export const LoginSection = ({ onLogoClick, onClose, onForgotPassword, onSignUp 
   });
 
   const handleKakaoLogin = () => {
+    if (!process.env.NEXT_PUBLIC_API_BASE_URL) {return;}
     window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/oauth2/authorization/kakao`;
   };
 

--- a/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
+++ b/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
@@ -48,7 +48,9 @@ export const LoginSection = ({ onLogoClick, onClose, onForgotPassword, onSignUp 
   });
 
   const handleKakaoLogin = () => {
-    if (!process.env.NEXT_PUBLIC_API_BASE_URL) {return;}
+    if (!process.env.NEXT_PUBLIC_API_BASE_URL) {
+      return;
+    }
     window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/oauth2/authorization/kakao`;
   };
 

--- a/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
+++ b/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
@@ -12,12 +12,11 @@ import { LoginModal } from '../LoginModal';
 interface LoginSectionProps {
   onLogoClick?: () => void;
   onClose?: () => void;
-  onKakaoLogin?: () => void;
   onForgotPassword?: () => void;
   onSignUp?: () => void;
 }
 
-export const LoginSection = ({ onLogoClick, onClose, onKakaoLogin, onForgotPassword, onSignUp }: LoginSectionProps) => {
+export const LoginSection = ({ onLogoClick, onClose, onForgotPassword, onSignUp }: LoginSectionProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
   const setUser = useAuthStore((state) => state.setUser);
@@ -48,6 +47,10 @@ export const LoginSection = ({ onLogoClick, onClose, onKakaoLogin, onForgotPassw
     }
   });
 
+  const handleKakaoLogin = () => {
+    window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/oauth2/authorization/kakao`;
+  };
+
   return (
     <LoginModal
       register={register}
@@ -56,7 +59,7 @@ export const LoginSection = ({ onLogoClick, onClose, onKakaoLogin, onForgotPassw
       onSubmit={onSubmit}
       onLogoClick={onLogoClick}
       onClose={onClose}
-      onKakaoLogin={onKakaoLogin}
+      onKakaoLogin={handleKakaoLogin}
       onForgotPassword={onForgotPassword}
       onSignUp={onSignUp}
     />

--- a/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
+++ b/apps/web/src/app/(auth)/_components/LoginSection/LoginSection.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { isAuthApiError, login } from '@/api/auth';
 import { loginSchema, type LoginFormValues } from '@/lib/validations/auth';
+import { useAuthStore } from '@/store/authStore';
 import { LoginModal } from '../LoginModal';
 
 interface LoginSectionProps {
@@ -16,19 +19,30 @@ interface LoginSectionProps {
 
 export const LoginSection = ({ onLogoClick, onClose, onKakaoLogin, onForgotPassword, onSignUp }: LoginSectionProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const setUser = useAuthStore((state) => state.setUser);
 
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
   });
 
-  const onSubmit = handleSubmit(async () => {
+  const onSubmit = handleSubmit(async (data) => {
     setIsLoading(true);
     try {
-      // NOTE: 로그인 API 연동
+      const user = await login(data);
+      setUser(user);
+      router.push('/home');
+    } catch (e) {
+      if (isAuthApiError(e) && e.code === 'INVALID_LOGIN_INFO') {
+        setError('password', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' });
+      } else {
+        setError('password', { message: '로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' });
+      }
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/app/(auth)/_components/SignupSection/SignupSection.tsx
+++ b/apps/web/src/app/(auth)/_components/SignupSection/SignupSection.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { isAuthApiError, signup } from '@/api/auth';
 import { signupSchema, type SignupFormValues } from '@/lib/validations/auth';
+import { useAuthStore } from '@/store/authStore';
 import { SignupModal } from '../SignupModal';
 
 interface SignupSectionProps {
@@ -14,19 +17,49 @@ interface SignupSectionProps {
 
 export const SignupSection = ({ onLogoClick, onClose, onLogin }: SignupSectionProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const setUser = useAuthStore((state) => state.setUser);
 
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<SignupFormValues>({
     resolver: zodResolver(signupSchema),
   });
 
-  const onSubmit = handleSubmit(async () => {
+  const onSubmit = handleSubmit(async (data) => {
     setIsLoading(true);
     try {
-      // NOTE: 회원가입 API 연동
+      const user = await signup({
+        email: data.email,
+        password: data.password,
+        passwordConfirm: data.passwordConfirm,
+        name: data.name,
+        phoneNumber: data.phone,
+        birthDate: data.birthDate,
+      });
+      setUser(user);
+      router.push('/home');
+    } catch (e) {
+      if (isAuthApiError(e) && e.code === 'VALIDATION_FAILED') {
+        const fieldErrors = e.error as Record<string, string>;
+        const fieldMap: Record<string, keyof SignupFormValues> = {
+          phoneNumber: 'phone',
+          email: 'email',
+          password: 'password',
+          passwordConfirm: 'passwordConfirm',
+          name: 'name',
+          birthDate: 'birthDate',
+        };
+        Object.entries(fieldErrors).forEach(([apiField, message]) => {
+          const formField = fieldMap[apiField] ?? apiField;
+          setError(formField as keyof SignupFormValues, { message });
+        });
+      } else {
+        setError('email', { message: '회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' });
+      }
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/app/(auth)/_components/SignupSection/SignupSection.tsx
+++ b/apps/web/src/app/(auth)/_components/SignupSection/SignupSection.tsx
@@ -43,7 +43,7 @@ export const SignupSection = ({ onLogoClick, onClose, onLogin }: SignupSectionPr
       setUser(user);
       router.push('/home');
     } catch (e) {
-      if (isAuthApiError(e) && e.code === 'VALIDATION_FAILED') {
+      if (isAuthApiError(e) && e.code === 'VALIDATION_FAILED' && typeof e.error === 'object' && e.error !== null) {
         const fieldErrors = e.error as Record<string, string>;
         const fieldMap: Record<string, keyof SignupFormValues> = {
           phoneNumber: 'phone',
@@ -54,8 +54,12 @@ export const SignupSection = ({ onLogoClick, onClose, onLogin }: SignupSectionPr
           birthDate: 'birthDate',
         };
         Object.entries(fieldErrors).forEach(([apiField, message]) => {
-          const formField = fieldMap[apiField] ?? apiField;
-          setError(formField as keyof SignupFormValues, { message });
+          const formField = fieldMap[apiField];
+          if (formField) {
+            setError(formField, { message });
+          } else {
+            setError('email', { message });
+          }
         });
       } else {
         setError('email', { message: '회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' });

--- a/apps/web/src/app/(main)/home/_mocks/home.mock.ts
+++ b/apps/web/src/app/(main)/home/_mocks/home.mock.ts
@@ -10,35 +10,35 @@ export const MOCK_SUMMARY_STATS: SummaryStats = {
 
 export const MOCK_HISTORY_ROWS: HistoryRow[] = [
   {
-    id: 1,
+    id: '1',
     date: '2026-04-15',
     analysisType: '리스크 진단',
     constructionType: '주거 32평 리모델링',
     risk: { type: 'danger', label: '누락 4건' },
   },
   {
-    id: 2,
+    id: '2',
     date: '2026-04-14',
     analysisType: '가견적서 생성',
     constructionType: '상업 20평 신규',
     risk: { type: 'none' },
   },
   {
-    id: 3,
+    id: '3',
     date: '2026-04-12',
     analysisType: '리스크 진단',
     constructionType: '주거 28평 리모델링',
     risk: { type: 'danger', label: '누락 2건' },
   },
   {
-    id: 4,
+    id: '4',
     date: '2026-04-10',
     analysisType: '가견적서 생성',
     constructionType: '주거 45평 전체',
     risk: { type: 'none' },
   },
   {
-    id: 5,
+    id: '5',
     date: '2026-04-05',
     analysisType: '리스크 진단',
     constructionType: '주거 32평 부분',

--- a/apps/web/src/app/(main)/home/_types/home.types.ts
+++ b/apps/web/src/app/(main)/home/_types/home.types.ts
@@ -1,7 +1,7 @@
 export type RiskStatus = { type: 'danger'; label: string } | { type: 'safe'; label: string } | { type: 'none' };
 
 export interface HistoryRow {
-  id: number;
+  id: string;
   date: string;
   analysisType: string;
   constructionType: string;

--- a/apps/web/src/app/(main)/home/page.tsx
+++ b/apps/web/src/app/(main)/home/page.tsx
@@ -1,36 +1,94 @@
+'use client';
+
 import { DellSquareIcon, DoneRingRoundFillIcon, SadIcon, vars } from '@muneo/design-system';
-import { type ComponentProps } from 'react';
+import { useEffect, useState } from 'react';
+import { getEstimates, getRiskDetections } from '@/api/history';
+import { useAuthStore } from '@/store/authStore';
 import { HistoryTable } from './_components/HistoryTable/HistoryTable';
 import { SummaryCard } from './_components/SummaryCard/SummaryCard';
-import { MOCK_GREETING_NAME, MOCK_HISTORY_ROWS, MOCK_SUMMARY_STATS } from './_mocks/home.mock';
+import { type HistoryRow, type SummaryStats } from './_types/home.types';
 import * as styles from './page.css';
 
-const SUMMARY_CARDS: Array<ComponentProps<typeof SummaryCard>> = [
-  {
-    icon: <DellSquareIcon width={22} height={22} style={{ color: vars.color.brand.secondary }} />,
-    label: '그동안 생성한 가견적서',
-    count: MOCK_SUMMARY_STATS.estimateCount,
-  },
-  {
-    icon: <DoneRingRoundFillIcon width={22} height={22} />,
-    label: '진단 완료한 견적',
-    count: MOCK_SUMMARY_STATS.diagnosedCount,
-  },
-  {
-    icon: <SadIcon width={22} height={22} />,
-    label: '리스크 발생 견적',
-    count: MOCK_SUMMARY_STATS.riskCount,
-    danger: true,
-  },
-];
+const toDate = (isoStr: string) => isoStr.slice(0, 10);
 
 const HomePage = () => {
+  const { user } = useAuthStore();
+  const [stats, setStats] = useState<SummaryStats>({ estimateCount: 0, diagnosedCount: 0, riskCount: 0 });
+  const [rows, setRows] = useState<HistoryRow[]>([]);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        const [estimates, risks] = await Promise.all([getEstimates(user.id), getRiskDetections(user.id)]);
+
+        const estimateRows: HistoryRow[] = estimates.map((item) => ({
+          id: item.id,
+          date: toDate(item.created_at),
+          analysisType: '가견적서 생성',
+          constructionType: `${item.input.공간유형} ${item.input.평수}평 (${item.input.공종.join(', ')})`,
+          vendor: null,
+          risk: { type: 'none' as const },
+        }));
+
+        const riskRows: HistoryRow[] = risks.map((item) => {
+          const { total_risk_items: totalRiskItems, chips } = item.result.report.summary;
+          const risk: HistoryRow['risk'] =
+            totalRiskItems === 0
+              ? { type: 'safe', label: '이상 없음' }
+              : { type: 'danger', label: chips.누락 > 0 ? `누락 ${chips.누락}건` : `위험 ${totalRiskItems}건` };
+
+          return {
+            id: item.id,
+            date: toDate(item.created_at),
+            analysisType: '리스크 진단',
+            constructionType: `${item.input.spaceType} ${item.input.pyeong}평`,
+            vendor: item.input.companyName,
+            risk,
+          };
+        });
+
+        const allRows = [...estimateRows, ...riskRows].sort((a, b) => b.date.localeCompare(a.date));
+        const riskCount = risks.filter((r) => r.result.report.summary.total_risk_items > 0).length;
+
+        setStats({ estimateCount: estimates.length, diagnosedCount: risks.length, riskCount });
+        setRows(allRows);
+      } catch (err) {
+        console.error('홈 데이터 로딩 실패:', err);
+      }
+    };
+
+    fetchData();
+  }, [user]);
+
+  const SUMMARY_CARDS = [
+    {
+      icon: <DellSquareIcon width={22} height={22} style={{ color: vars.color.brand.secondary }} />,
+      label: '그동안 생성한 가견적서',
+      count: stats.estimateCount,
+    },
+    {
+      icon: <DoneRingRoundFillIcon width={22} height={22} />,
+      label: '진단 완료한 견적',
+      count: stats.diagnosedCount,
+    },
+    {
+      icon: <SadIcon width={22} height={22} />,
+      label: '리스크 발생 견적',
+      count: stats.riskCount,
+      danger: true as const,
+    },
+  ];
+
   return (
     <div className={styles.page}>
       <div className={styles.content}>
         <div className={styles.greetingSection}>
           <h1 className={styles.greetingTitle}>
-            안녕하세요, <span className={styles.greetingName}>{MOCK_GREETING_NAME}</span> 님
+            안녕하세요, <span className={styles.greetingName}>{user?.name ?? ''}</span> 님
           </h1>
           <p className={styles.greetingSubtitle}>오늘도 문어와 함께 현명한 의사 결정을 내리세요.</p>
         </div>
@@ -41,7 +99,7 @@ const HomePage = () => {
           ))}
         </div>
 
-        <HistoryTable rows={MOCK_HISTORY_ROWS} />
+        <HistoryTable rows={rows} />
       </div>
     </div>
   );

--- a/apps/web/src/app/(main)/home/page.tsx
+++ b/apps/web/src/app/(main)/home/page.tsx
@@ -18,12 +18,18 @@ const HomePage = () => {
 
   useEffect(() => {
     if (!user) {
+      setStats({ estimateCount: 0, diagnosedCount: 0, riskCount: 0 });
+      setRows([]);
       return;
     }
+
+    let mounted = true;
 
     const fetchData = async () => {
       try {
         const [estimates, risks] = await Promise.all([getEstimates(user.id), getRiskDetections(user.id)]);
+
+        if (!mounted) {return;}
 
         const estimateRows: HistoryRow[] = estimates.map((item) => ({
           id: item.id,
@@ -57,11 +63,15 @@ const HomePage = () => {
         setStats({ estimateCount: estimates.length, diagnosedCount: risks.length, riskCount });
         setRows(allRows);
       } catch (err) {
+        if (!mounted) {return;}
         console.error('홈 데이터 로딩 실패:', err);
       }
     };
 
     fetchData();
+    return () => {
+      mounted = false;
+    };
   }, [user]);
 
   const SUMMARY_CARDS = [

--- a/apps/web/src/app/(main)/home/page.tsx
+++ b/apps/web/src/app/(main)/home/page.tsx
@@ -29,7 +29,9 @@ const HomePage = () => {
       try {
         const [estimates, risks] = await Promise.all([getEstimates(user.id), getRiskDetections(user.id)]);
 
-        if (!mounted) {return;}
+        if (!mounted) {
+          return;
+        }
 
         const estimateRows: HistoryRow[] = estimates.map((item) => ({
           id: item.id,
@@ -63,7 +65,9 @@ const HomePage = () => {
         setStats({ estimateCount: estimates.length, diagnosedCount: risks.length, riskCount });
         setRows(allRows);
       } catch (err) {
-        if (!mounted) {return;}
+        if (!mounted) {
+          return;
+        }
         console.error('홈 데이터 로딩 실패:', err);
       }
     };

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -25,7 +25,9 @@ const MainLayout = ({ children }: { children: ReactNode }) => {
     (Object.entries(NAV_TO_PATH).find(([, path]) => pathname.startsWith(path))?.[0] as SidebarNavId) ?? 'home';
 
   const handleLogout = async () => {
-    await logout().catch(() => {});
+    await logout().catch((err) => {
+      console.error('로그아웃 API 오류:', err);
+    });
     clearUser();
     window.location.href = '/';
   };

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -3,6 +3,8 @@
 import { Sidebar, type SidebarNavId } from '@muneo/design-system';
 import { usePathname, useRouter } from 'next/navigation';
 import { type ReactNode } from 'react';
+import { logout } from '@/api/auth';
+import { useAuthStore } from '@/store/authStore';
 import * as styles from './layout.css';
 
 const NAV_TO_PATH: Record<SidebarNavId, string> = {
@@ -13,14 +15,20 @@ const NAV_TO_PATH: Record<SidebarNavId, string> = {
   settings: '/settings',
 };
 
-const MOCK_USER = { name: '김민수', email: 'minsu@email.com' };
-
 const MainLayout = ({ children }: { children: ReactNode }) => {
   const pathname = usePathname();
   const router = useRouter();
+  const user = useAuthStore((state) => state.user);
+  const clearUser = useAuthStore((state) => state.clearUser);
 
   const activeItem =
     (Object.entries(NAV_TO_PATH).find(([, path]) => pathname.startsWith(path))?.[0] as SidebarNavId) ?? 'home';
+
+  const handleLogout = async () => {
+    await logout().catch(() => {});
+    clearUser();
+    window.location.href = '/';
+  };
 
   return (
     <div className={styles.wrapper}>
@@ -28,7 +36,8 @@ const MainLayout = ({ children }: { children: ReactNode }) => {
         activeItem={activeItem}
         onItemClick={(id) => router.push(NAV_TO_PATH[id])}
         onItemHover={(id) => router.prefetch(NAV_TO_PATH[id])}
-        user={MOCK_USER}
+        onLogout={handleLogout}
+        user={user ?? { name: '', email: '' }}
       />
       <main className={styles.main}>{children}</main>
     </div>

--- a/apps/web/src/app/auth/callback/error/page.tsx
+++ b/apps/web/src/app/auth/callback/error/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Button } from '@muneo/design-system';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const SocialLoginErrorPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const reason = searchParams.get('reason');
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '24px',
+        backgroundColor: '#f3f4f6',
+      }}
+    >
+      <p style={{ fontSize: '16px', color: '#374151', textAlign: 'center' }}>
+        {reason ?? '카카오 로그인 중 오류가 발생했습니다.'}
+      </p>
+      <Button variant="primary" onClick={() => router.push('/login')}>
+        다시 로그인하기
+      </Button>
+    </div>
+  );
+};
+
+export default SocialLoginErrorPage;

--- a/apps/web/src/app/auth/callback/error/page.tsx
+++ b/apps/web/src/app/auth/callback/error/page.tsx
@@ -2,8 +2,9 @@
 
 import { Button } from '@muneo/design-system';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 
-const SocialLoginErrorPage = () => {
+const ErrorContent = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const reason = searchParams.get('reason');
@@ -29,5 +30,11 @@ const SocialLoginErrorPage = () => {
     </div>
   );
 };
+
+const SocialLoginErrorPage = () => (
+  <Suspense>
+    <ErrorContent />
+  </Suspense>
+);
 
 export default SocialLoginErrorPage;

--- a/apps/web/src/app/auth/callback/error/page.tsx
+++ b/apps/web/src/app/auth/callback/error/page.tsx
@@ -4,6 +4,13 @@ import { Button } from '@muneo/design-system';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 
+const REASON_MESSAGES: Record<string, string> = {
+  SOCIAL_LOGIN_FAILED: '카카오 로그인에 실패했습니다.',
+  ACCOUNT_LOCKED: '계정이 잠겨 있습니다. 고객센터에 문의해주세요.',
+  SERVER_ERROR: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+};
+const DEFAULT_MESSAGE = '카카오 로그인 중 오류가 발생했습니다.';
+
 const ErrorContent = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -22,7 +29,7 @@ const ErrorContent = () => {
       }}
     >
       <p style={{ fontSize: '16px', color: '#374151', textAlign: 'center' }}>
-        {reason ?? '카카오 로그인 중 오류가 발생했습니다.'}
+        {(reason && REASON_MESSAGES[reason]) ?? DEFAULT_MESSAGE}
       </p>
       <Button variant="primary" onClick={() => router.push('/login')}>
         다시 로그인하기

--- a/apps/web/src/app/auth/callback/signup/_components/socialSignup.css.ts
+++ b/apps/web/src/app/auth/callback/signup/_components/socialSignup.css.ts
@@ -1,0 +1,51 @@
+import { vars } from '@muneo/design-system';
+import { style } from '@vanilla-extract/css';
+
+export const page = style({
+  minHeight: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: '#f3f4f6',
+});
+
+export const card = style({
+  position: 'relative',
+  backgroundColor: vars.color.white,
+  borderRadius: '16px',
+  padding: `45px ${vars.space['3xl']}`,
+  width: '100%',
+  maxWidth: '420px',
+});
+
+export const inner = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '27px',
+});
+
+export const upper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '20px',
+  width: '100%',
+});
+
+export const description = style({
+  fontFamily: vars.typography.fontFamily,
+  fontSize: vars.typography.fontSize.sm,
+  color: vars.color.neutral.n500,
+  textAlign: 'center',
+});
+
+export const formSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.md,
+  width: '100%',
+});
+
+export const fullWidth = style({
+  width: '100%',
+});

--- a/apps/web/src/app/auth/callback/signup/page.tsx
+++ b/apps/web/src/app/auth/callback/signup/page.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, TextField } from '@muneo/design-system';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useId } from 'react';
+import { Suspense, useEffect, useId } from 'react';
 import { useForm } from 'react-hook-form';
 import { isAuthApiError, socialSignup } from '@/api/auth';
 import { AuthModalHeader } from '@/app/(auth)/_components/AuthModalHeader';
@@ -31,7 +31,7 @@ const FIELDS = [
   maxLength?: number;
 }>;
 
-const SocialSignupPage = () => {
+const SocialSignupContent = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const ticket = searchParams.get('ticket');
@@ -118,5 +118,11 @@ const SocialSignupPage = () => {
     </div>
   );
 };
+
+const SocialSignupPage = () => (
+  <Suspense>
+    <SocialSignupContent />
+  </Suspense>
+);
 
 export default SocialSignupPage;

--- a/apps/web/src/app/auth/callback/signup/page.tsx
+++ b/apps/web/src/app/auth/callback/signup/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, TextField } from '@muneo/design-system';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useId } from 'react';
+import { useForm } from 'react-hook-form';
+import { isAuthApiError, socialSignup } from '@/api/auth';
+import { AuthModalHeader } from '@/app/(auth)/_components/AuthModalHeader';
+import { socialSignupSchema, type SocialSignupFormValues } from '@/lib/validations/auth';
+import { useAuthStore } from '@/store/authStore';
+import * as styles from './_components/socialSignup.css';
+
+const FIELDS = [
+  {
+    name: 'name',
+    label: '이름',
+    type: 'text',
+    placeholder: '텍스트를 입력하세요',
+    autoComplete: 'name',
+    maxLength: 20,
+  },
+  { name: 'phone', label: '연락처', type: 'tel', placeholder: '010-1234-5678', autoComplete: 'tel' },
+  { name: 'birthDate', label: '생년월일', type: 'text', placeholder: 'YYYY-MM-DD', autoComplete: 'bday' },
+] as const satisfies ReadonlyArray<{
+  name: keyof SocialSignupFormValues;
+  label: string;
+  type: string;
+  placeholder: string;
+  autoComplete: string;
+  maxLength?: number;
+}>;
+
+const SocialSignupPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const ticket = searchParams.get('ticket');
+  const setUser = useAuthStore((state) => state.setUser);
+  const formId = useId();
+
+  useEffect(() => {
+    if (!ticket) {
+      router.replace('/login');
+    }
+  }, [ticket, router]);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<SocialSignupFormValues>({
+    resolver: zodResolver(socialSignupSchema),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    if (!ticket) {
+      return;
+    }
+    try {
+      const user = await socialSignup({ ticket, name: data.name, phoneNumber: data.phone, birthDate: data.birthDate });
+      setUser(user);
+      router.replace('/home');
+    } catch (e) {
+      if (isAuthApiError(e)) {
+        if (e.code === 'SOCIAL_SIGNUP_TICKET_EXPIRED') {
+          router.replace('/login');
+        } else if (e.code === 'VALIDATION_FAILED' && typeof e.error === 'object' && e.error !== null) {
+          const fieldMap: Record<string, keyof SocialSignupFormValues> = {
+            name: 'name',
+            phoneNumber: 'phone',
+            birthDate: 'birthDate',
+          };
+          Object.entries(e.error as Record<string, string>).forEach(([apiField, message]) => {
+            const formField = fieldMap[apiField];
+            if (formField) {
+              setError(formField, { message });
+            }
+          });
+        } else {
+          setError('name', { message: '회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' });
+        }
+      } else {
+        setError('name', { message: '회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' });
+      }
+    }
+  });
+
+  if (!ticket) {
+    return null;
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <form className={styles.inner} onSubmit={onSubmit} noValidate>
+          <div className={styles.upper}>
+            <AuthModalHeader onLogoClick={() => router.push('/')} />
+            <p className={styles.description}>카카오 계정으로 가입을 완료해주세요.</p>
+            <div className={styles.formSection}>
+              {FIELDS.map(({ name, label, ...fieldProps }) => (
+                <TextField
+                  key={name}
+                  id={`${formId}-${name}`}
+                  label={label}
+                  error={errors[name]?.message}
+                  {...fieldProps}
+                  {...register(name)}
+                />
+              ))}
+            </div>
+          </div>
+          <Button type="submit" variant="primary" className={styles.fullWidth} disabled={isSubmitting}>
+            가입 완료
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SocialSignupPage;

--- a/apps/web/src/app/auth/callback/success/page.tsx
+++ b/apps/web/src/app/auth/callback/success/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { refresh } from '@/api/auth';
+import { useAuthStore } from '@/store/authStore';
+
+const SocialLoginSuccessPage = () => {
+  const router = useRouter();
+  const setUser = useAuthStore((state) => state.setUser);
+
+  useEffect(() => {
+    refresh()
+      .then((user) => {
+        setUser(user);
+        router.replace('/home');
+      })
+      .catch(() => {
+        router.replace('/login');
+      });
+  }, [router, setUser]);
+
+  return null;
+};
+
+export default SocialLoginSuccessPage;

--- a/apps/web/src/lib/validations/auth.ts
+++ b/apps/web/src/lib/validations/auth.ts
@@ -23,3 +23,11 @@ export const loginSchema = z.object({
 });
 
 export type LoginFormValues = z.infer<typeof loginSchema>;
+
+export const socialSignupSchema = z.object({
+  name: nameField,
+  phone: phoneField,
+  birthDate: birthDateField,
+});
+
+export type SocialSignupFormValues = z.infer<typeof socialSignupSchema>;

--- a/apps/web/src/lib/validations/fields.ts
+++ b/apps/web/src/lib/validations/fields.ts
@@ -27,7 +27,9 @@ export const birthDateField = z
     return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
   }, '존재하지 않는 날짜입니다.')
   .refine((val) => {
+    const [year, month, day] = val.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    return new Date(val) <= today;
+    return date <= today;
   }, '미래 날짜는 입력할 수 없습니다.');

--- a/apps/web/src/lib/validations/fields.ts
+++ b/apps/web/src/lib/validations/fields.ts
@@ -25,4 +25,9 @@ export const birthDateField = z
     const [year, month, day] = val.split('-').map(Number);
     const date = new Date(year, month - 1, day);
     return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
-  }, '존재하지 않는 날짜입니다.');
+  }, '존재하지 않는 날짜입니다.')
+  .refine((val) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return new Date(val) <= today;
+  }, '미래 날짜는 입력할 수 없습니다.');

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -30,5 +30,6 @@ export const config = {
     '/settings/:path*',
     '/login',
     '/signup',
+    '/auth/callback/:path*',
   ],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+const PROTECTED_PATHS = ['/home', '/estimate', '/analysis', '/history', '/settings'];
+const AUTH_PATHS = ['/login', '/signup'];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const accessToken = request.cookies.get('access_token');
+
+  const isProtected = PROTECTED_PATHS.some((p) => pathname.startsWith(p));
+  const isAuthRoute = AUTH_PATHS.some((p) => pathname.startsWith(p));
+
+  if (isProtected && !accessToken) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (isAuthRoute && accessToken) {
+    return NextResponse.redirect(new URL('/home', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/home/:path*',
+    '/estimate/:path*',
+    '/analysis/:path*',
+    '/history/:path*',
+    '/settings/:path*',
+    '/login',
+    '/signup',
+  ],
+};

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,7 +5,7 @@ const AUTH_PATHS = ['/login', '/signup'];
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const accessToken = request.cookies.get('access_token');
+  const accessToken = request.cookies.get('access_token')?.value;
 
   const isProtected = PROTECTED_PATHS.some((p) => pathname.startsWith(p));
   const isAuthRoute = AUTH_PATHS.some((p) => pathname.startsWith(p));

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 const PROTECTED_PATHS = ['/home', '/estimate', '/analysis', '/history', '/settings'];
 const AUTH_PATHS = ['/login', '/signup'];
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get('access_token');
 

--- a/apps/web/src/store/authStore.ts
+++ b/apps/web/src/store/authStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { type AuthUser } from '@/types/auth';
+
+interface AuthStore {
+  user: AuthUser | null;
+  setUser: (user: AuthUser) => void;
+  clearUser: () => void;
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}));

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -23,6 +23,13 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface SocialSignupRequest {
+  ticket: string;
+  name: string;
+  phoneNumber: string;
+  birthDate: string;
+}
+
 export interface AuthApiError {
   code: string;
   error?: Record<string, string> | string;

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -1,0 +1,29 @@
+export interface AuthUser {
+  id: number;
+  email: string;
+  name: string;
+  phoneNumber: string;
+  birthDate: string;
+  authProvider: 'LOCAL' | 'KAKAO';
+  profileCompleted: boolean;
+  role: 'USER' | 'ADMIN';
+}
+
+export interface SignupRequest {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  name: string;
+  phoneNumber: string;
+  birthDate: string;
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface AuthApiError {
+  code: string;
+  error?: Record<string, string> | string;
+}

--- a/packages/design-system/src/ui/Sidebar/Sidebar.css.ts
+++ b/packages/design-system/src/ui/Sidebar/Sidebar.css.ts
@@ -185,3 +185,23 @@ export const userEmailStyle = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
 });
+
+export const logoutButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '24px',
+  height: '24px',
+  marginLeft: 'auto',
+  flexShrink: 0,
+  background: 'none',
+  border: 'none',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  color: vars.color.neutral.n400,
+  padding: 0,
+  ':hover': {
+    color: vars.color.neutral.n600,
+    backgroundColor: vars.color.neutral.n100,
+  },
+});

--- a/packages/design-system/src/ui/Sidebar/Sidebar.tsx
+++ b/packages/design-system/src/ui/Sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import SearchIcon from '../../assets/icons/SearchIcon';
 import SettingFillIcon from '../../assets/icons/SettingFillIcon';
 import {
   avatar,
+  logoutButton,
   logoArea,
   navIcon,
   navIndicator,
@@ -36,6 +37,7 @@ export interface SidebarProps {
   activeItem?: SidebarNavId;
   onItemClick?: (id: SidebarNavId) => void;
   onItemHover?: (id: SidebarNavId) => void;
+  onLogout?: () => void;
   user?: SidebarUser;
   className?: string;
 }
@@ -54,7 +56,7 @@ const NAV_ITEMS: NavItemDef[] = [
   { id: 'settings', label: '내 정보', icon: <SettingFillIcon /> },
 ];
 
-export const Sidebar = ({ activeItem, onItemClick, onItemHover, user, className }: SidebarProps) => {
+export const Sidebar = ({ activeItem, onItemClick, onItemHover, onLogout, user, className }: SidebarProps) => {
   return (
     <aside className={`${sidebar}${className ? ` ${className}` : ''}`}>
       <div className={topSection}>
@@ -93,6 +95,24 @@ export const Sidebar = ({ activeItem, onItemClick, onItemHover, user, className 
             <p className={userNameStyle}>{user.name}</p>
             <p className={userEmailStyle}>{user.email}</p>
           </div>
+          {onLogout && (
+            <button type="button" className={logoutButton} onClick={onLogout} aria-label="로그아웃">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            </button>
+          )}
         </div>
       )}
     </aside>


### PR DESCRIPTION
## ✨ 주요 변경사항

- 이메일/비밀번호 로그인·회원가입 폼 실 API 연동
- 카카오 소셜 로그인 연동 (/oauth2/authorization/kakao 직접 redirect 방식)
- 소셜 로그인 OAuth 콜백 페이지 추가 (/auth/callback/signup, /auth/callback/success, /auth/callback/error)
- Next.js rewrite 기반 API 프록시 설정으로 CORS 문제 해결
- 인증 상태 관리 인프라 구성 (타입, Zustand 스토어, 미들웨어)
- 홈 대시보드 실 API 연동 (목 데이터 제거, 병렬 호출)
- 로그아웃 기능 추가

---

## 📝 작업 상세 내용

/auth/callback/success/page.tsx는 현재 POST /api/v1/auth/refresh를 호출하는 방식으로 구현되어 있습니다. 그런데 백엔드가 신규 회원과 마찬가지로 기존 회원 로그인 콜백에도 ticket=? 파라미터를 사용하는 방식으로 변경된 것으로 보입니다. 기존 회원 로그인 콜백 API 스펙을 백엔드 팀과 확인한 뒤 수정이 필요합니다.

---

## ✅ 체크리스트

- [x] PR 본문에 `Close #번호` 추가
- [x] 불필요한 주석, 디버깅 코드 제거
- [ ] 기능 테스트 및 정상 동작 확인
- [x] 커밋컨벤션 / 코드컨벤션 준수

---

## 📸 스크린샷 (선택)



---

## 🔍 기타 참고사항

- /auth/callback/success 미완성 이슈

백엔드 OAuth 플로우 변경으로 인해 기존 회원 로그인 성공 콜백(/auth/callback/success)의 처리 방식이 확정되지 않은 상태입니다. 현재는 임시로 refresh() API를 호출하고 있으나, 백엔드에서 해당 경로에도 ticket 파라미터를 내려준다면 signup 페이지와 동일한 방식으로 수정이 필요합니다.

- 프로덕션 404 이슈

apps/web/src/app/auth/ 디렉토리가 이번 PR 이전까지 git에 추가되지 않아 프로덕션 배포에 콜백 라우트가 존재하지 않았습니다. 이 PR 병합 및 배포 후 해소됩니다.

---

## 🔗 관련 이슈

<!-- 반드시 관련 이슈 번호를 적어주세요. 예시: Close #123 -->

- Close #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 완전한 사용자 인증 시스템 (회원가입, 로그인, 로그아웃, 토큰 갱신)
* Kakao를 통한 소셜 로그인 지원
* 예측 결과 및 위험 진단 이력 조회 기능
* 보호된 페이지 접근 제어 시스템

## 개선사항

* 사이드바에 로그아웃 버튼 추가
* API 클라이언트 동적 URL 라우팅 최적화
* 홈 페이지에 실제 사용자 데이터 연동

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaxedOut-Muneo/Muneo-Client/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->