### PR TITLE
[Hotfix] - 챗봇 오류 수정

### DIFF
--- a/apps/web/src/api/chatbot/api.ts
+++ b/apps/web/src/api/chatbot/api.ts
@@ -2,9 +2,12 @@ import { client } from '../client';
 import { toApiError } from '../errors';
 import { type ChatRequest, type ChatResponse } from './types';
 
+// 챗봇 전용 타임아웃 설정
+const CHATBOT_TIMEOUT_MS = 30_000;
+
 export const askChatbot = async (data: ChatRequest): Promise<ChatResponse> => {
   try {
-    return await client.post('api/v1/chatbot/chat', { json: data }).json<ChatResponse>();
+    return await client.post('api/v1/chatbot/chat', { json: data, timeout: CHATBOT_TIMEOUT_MS }).json<ChatResponse>();
   } catch (e) {
     throw toApiError(e);
   }


### PR DESCRIPTION
## ✨ 주요 변경사항

<!-- 여기에 어떤 변경을 했는지 설명해주세요-->
- 챗봇 응답 타임아웃을 기본 10s에서 **30s로 확장**해 RAG 응답이 10s를 살짝 넘는 경우(11s 측정) "API 오류가 발생했습니다" 폴백이 뜨던 문제 해결

---

## 📝 작업 상세 내용

<!--리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요-->
### 원인
- ky 기본 client의 `timeout: 10000` 설정 (`apps/web/src/api/client.ts`)
- 챗봇 RAG 응답이 평균 ~11s 소요 → client 측 abort → `TimeoutError`
- `useChatMessages.onError`에서 `isApiError(error)` 가 false (TimeoutError는 ApiError 아님) → `FALLBACK_ERROR_MESSAGE` "API 오류가 발생했습니다" 노출

### 수정
[apps/web/src/api/chatbot/api.ts](apps/web/src/api/chatbot/api.ts)에 챗봇 endpoint 전용 타임아웃 30s 적용:

```ts
const CHATBOT_TIMEOUT_MS = 30_000;
client.post('api/v1/chatbot/chat', { json: data, timeout: CHATBOT_TIMEOUT_MS })

---

## ✅ 체크리스트

- [ ] PR 본문에 `Close #번호` 추가
- [ ] 불필요한 주석, 디버깅 코드 제거
- [ ] 기능 테스트 및 정상 동작 확인
- [ ] 커밋컨벤션 / 코드컨벤션 준수

---

## 📸 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능) -->

---

## 🔍 기타 참고사항

<!--리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요-->
-30s는 RAG의 변동 폭(11~25s 범위)을 충분히 흡수할 안전 마진. 60s는 과해서 실제 장애 시 사용자 대기 시간 길어짐 → 30s 채택
향후 RAG 응답이 자주 25s+를 찍기 시작하면 백엔드 응답 시간 최적화가 우선, 그 다음 timeout 재조정

---

## 🔗 관련 이슈

<!-- 반드시 관련 이슈 번호를 적어주세요. 예시: Close #123 -->

- Close #56 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 챗봇 서비스의 요청 타임아웃을 설정했습니다. 이제 응답이 너무 오래 걸리는 경우 자동으로 요청이 종료되어 사용자 경험이 개선됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaxedOut-Muneo/Muneo-Client/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->